### PR TITLE
Add umbrella header for dynamic framework

### DIFF
--- a/InflectorKit.podspec
+++ b/InflectorKit.podspec
@@ -8,5 +8,6 @@ Pod::Spec.new do |s|
   s.authors  = { 'Mattt Thompson' => 'm@mattt.me' }
   s.source   = { :git => 'https://github.com/mattt/InflectorKit.git', :tag => '0.0.1' }
   s.source_files = 'InflectorKit'
+  s.module_map = 'InflectorKit/InflectorKit.modulemap'
   s.requires_arc = true
 end

--- a/InflectorKit/InflectorKit.h
+++ b/InflectorKit/InflectorKit.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+#import "NSString+InflectorKit.h"
+#import "TTTStringInflector.h"
+
+FOUNDATION_EXPORT double InflectorKitVersionNumber;
+FOUNDATION_EXPORT const unsigned char InflectorKitVersionString[];

--- a/InflectorKit/InflectorKit.modulemap
+++ b/InflectorKit/InflectorKit.modulemap
@@ -1,0 +1,6 @@
+framework module InflectorKit {
+  umbrella header "InflectorKit.h"
+
+  export *
+  module * { export * }
+}


### PR DESCRIPTION
Fixes warning, and sometimes error, when building as a dynamic framework in CocoaPods.
