### PR TITLE
Added -[NSString toQuantity:]

### DIFF
--- a/InflectorKit/NSString+InflectorKit.h
+++ b/InflectorKit/NSString+InflectorKit.h
@@ -37,4 +37,9 @@
  */
 - (NSString *)pluralizedString;
 
+/**
+ 
+ */
+- (NSString *)toQuantity:(NSInteger)quantity;
+
 @end

--- a/InflectorKit/NSString+InflectorKit.m
+++ b/InflectorKit/NSString+InflectorKit.m
@@ -33,4 +33,10 @@
     return [[TTTStringInflector defaultInflector] pluralize:self];
 }
 
+- (NSString *)toQuantity:(NSInteger)quantity {
+    NSString *quantitized = quantity == 1 ? [self singularizedString] : [self pluralizedString];
+    
+    return [NSString stringWithFormat:@"%li %@", (long)quantity, quantitized];
+}
+
 @end


### PR DESCRIPTION
Added an additional instance method to the category to return a NSString representing the it's quantity parameter, with the correct pluralization of the receiver appended to it.

e.x.

``` objective-c
NSLog(@"%@", [@"thread" toQuantity:0]); // 0 threads
NSLog(@"%@", [@"thread" toQuantity:1]); // 1 thread
NSLog(@"%@", [@"thread" toQuantity:2]); // 2 threads
```
